### PR TITLE
Add regression test for SendNewMessage radio delay handling

### DIFF
--- a/VAICOM.Tests/SendNewMessageTests.cs
+++ b/VAICOM.Tests/SendNewMessageTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using VAICOM;
+using VAICOM.Client;
+using VAICOM.Products;
+using VAICOM.Settings;
+using Xunit;
+
+public class SendNewMessageTests
+{
+    private class DummyDictation
+    {
+        public bool IsOn() => false;
+    }
+
+    private class DummyProxy
+    {
+        public DummyDictation Dictation { get; } = new DummyDictation();
+        public void WriteToLog(string message, string color) { }
+    }
+
+    [Fact]
+    public void SendNewMessage_AllowsNullRadioDelayAndTriggersUpdate()
+    {
+        // Arrange
+        State.Proxy = new DummyProxy();
+        State.SendSocket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        State.SendIpEndPoint = new IPEndPoint(IPAddress.Loopback, 12345);
+        State.activeconfig = new Config { ForcedLanguage = 0 };
+        State.currentlicense = string.Empty;
+        State.currentradiodevicename = string.Empty;
+        State.currentmodule = new DCSmodule { radiodelay = null };
+        State.currentmessage = new DcsClient.Message.CommsMessage { command = 4000 };
+        State.lastupdaterequesttimer = -1;
+
+        // Act
+        Exception ex = Record.Exception(() => DcsClient.Message.SendNewMessage());
+
+        // Assert
+        Assert.Null(ex);
+        Assert.Equal(0, State.lastupdaterequesttimer);
+    }
+}

--- a/VAICOM.Tests/VAICOM.Tests.csproj
+++ b/VAICOM.Tests/VAICOM.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\VAICOM\VAICOM.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.3" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/VAICOM/Client/Message construction/SendNewMessage.cs
+++ b/VAICOM/Client/Message construction/SendNewMessage.cs
@@ -22,15 +22,7 @@ namespace VAICOM
                         if (State.currentmessage.command.Equals(4000))
                         {
                             // for Select command
-                            int delay = 0;
-                            if (!State.currentmodule.radiodelay.Equals(null))
-                            {
-                                delay = State.currentmodule.radiodelay; // allow some time for radio to tune
-                            }
-                            else
-                            {
-                                delay = 0;
-                            }
+                            int delay = State.currentmodule?.radiodelay ?? 0; // allow some time for radio to tune
                             Thread.Sleep(delay);
                             DcsClient.SendUpdateRequest(); // get an update directly after
                         }

--- a/VAICOM/Products/DCSModules.cs
+++ b/VAICOM/Products/DCSModules.cs
@@ -13,7 +13,7 @@ namespace VAICOM
             public string Name;
             public string Alias;
             public string SpeechAlias;
-            public int radiodelay;
+            public int? radiodelay;
             public int chnoffset;
             public bool ProOnly;
             public bool IsFC;

--- a/VAICOM28.sln
+++ b/VAICOM28.sln
@@ -14,9 +14,11 @@ EndProject
 Project("{54435603-DBB4-11D2-8724-00A0C9A8B90C}") = "VAICOM_Installer", "VAICOM_Installer\VAICOM_Installer.vdproj", "{C040815E-C198-43BF-BB2B-AD05B526EBF8}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{81179EDD-FCC9-438D-8186-1AEF756CC802}"
-	ProjectSection(SolutionItems) = preProject
-		Directory.Build.targets = Directory.Build.targets
-	EndProjectSection
+        ProjectSection(SolutionItems) = preProject
+                Directory.Build.targets = Directory.Build.targets
+        EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VAICOM.Tests", "VAICOM.Tests\VAICOM.Tests.csproj", "{B71AE524-858E-4294-8522-8EB20E035073}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -100,10 +102,26 @@ Global
 		{C040815E-C198-43BF-BB2B-AD05B526EBF8}.Release 3.5 Client|x64.ActiveCfg = Release
 		{C040815E-C198-43BF-BB2B-AD05B526EBF8}.Release 4|Any CPU.ActiveCfg = Release
 		{C040815E-C198-43BF-BB2B-AD05B526EBF8}.Release 4|x64.ActiveCfg = Release
-		{C040815E-C198-43BF-BB2B-AD05B526EBF8}.Release|Any CPU.ActiveCfg = Release
-		{C040815E-C198-43BF-BB2B-AD05B526EBF8}.Release|Any CPU.Build.0 = Release
-		{C040815E-C198-43BF-BB2B-AD05B526EBF8}.Release|x64.ActiveCfg = Release
-	EndGlobalSection
+                {C040815E-C198-43BF-BB2B-AD05B526EBF8}.Release|Any CPU.ActiveCfg = Release
+                {C040815E-C198-43BF-BB2B-AD05B526EBF8}.Release|Any CPU.Build.0 = Release
+                {C040815E-C198-43BF-BB2B-AD05B526EBF8}.Release|x64.ActiveCfg = Release
+                {B71AE524-858E-4294-8522-8EB20E035073}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {B71AE524-858E-4294-8522-8EB20E035073}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {B71AE524-858E-4294-8522-8EB20E035073}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {B71AE524-858E-4294-8522-8EB20E035073}.Debug|x64.Build.0 = Debug|Any CPU
+                {B71AE524-858E-4294-8522-8EB20E035073}.Release 3.5 Client|Any CPU.ActiveCfg = Release|Any CPU
+                {B71AE524-858E-4294-8522-8EB20E035073}.Release 3.5 Client|Any CPU.Build.0 = Release|Any CPU
+                {B71AE524-858E-4294-8522-8EB20E035073}.Release 3.5 Client|x64.ActiveCfg = Release|Any CPU
+                {B71AE524-858E-4294-8522-8EB20E035073}.Release 3.5 Client|x64.Build.0 = Release|Any CPU
+                {B71AE524-858E-4294-8522-8EB20E035073}.Release 4|Any CPU.ActiveCfg = Release|Any CPU
+                {B71AE524-858E-4294-8522-8EB20E035073}.Release 4|Any CPU.Build.0 = Release|Any CPU
+                {B71AE524-858E-4294-8522-8EB20E035073}.Release 4|x64.ActiveCfg = Release|Any CPU
+                {B71AE524-858E-4294-8522-8EB20E035073}.Release 4|x64.Build.0 = Release|Any CPU
+                {B71AE524-858E-4294-8522-8EB20E035073}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {B71AE524-858E-4294-8522-8EB20E035073}.Release|Any CPU.Build.0 = Release|Any CPU
+                {B71AE524-858E-4294-8522-8EB20E035073}.Release|x64.ActiveCfg = Release|Any CPU
+                {B71AE524-858E-4294-8522-8EB20E035073}.Release|x64.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add `VAICOM.Tests` project with `SendNewMessage` regression test
- allow `DCSmodule.radiodelay` to be nullable and handle null in `SendNewMessage`

## Testing
- `dotnet test VAICOM.Tests/VAICOM.Tests.csproj` *(fails: Invalid Resx file. System.IO.DirectoryNotFoundException: Could not find a part of the path '/workspace/VAICOM-Community/ChatterThemepack/resources/audio/themes/chatter/nato/nato animal 4mins(01).wav')*

------
https://chatgpt.com/codex/tasks/task_e_688c42d3d7b48333882d56530cf8cec7