### PR TITLE
Handle null radio delay in SendNewMessage

### DIFF
--- a/VAICOM/Client/Message construction/SendNewMessage.cs
+++ b/VAICOM/Client/Message construction/SendNewMessage.cs
@@ -23,9 +23,9 @@ namespace VAICOM
                         {
                             // for Select command
                             int delay = 0;
-                            if (!State.currentmodule.radiodelay.Equals(null))
+                            if (State.currentmodule.radiodelay != null)
                             {
-                                delay = State.currentmodule.radiodelay; // allow some time for radio to tune
+                                delay = (int)State.currentmodule.radiodelay; // allow some time for radio to tune
                             }
                             else
                             {


### PR DESCRIPTION
## Summary
- use null check when reading module radio delay

## Testing
- `dotnet build` (fails: could not find a part of the path .../ChatterThemepack/...wav)


------
https://chatgpt.com/codex/tasks/task_e_688c429c0ee08333ac4b0639055f00fb